### PR TITLE
Fix storesview

### DIFF
--- a/Jitterz Mobile/views/storesView.html
+++ b/Jitterz Mobile/views/storesView.html
@@ -1,6 +1,6 @@
 <div id="stores" 
      data-role="view" data-title="Stores" data-style="inset"
-     data-init="storesInit" data-show="onStoresShow"
+     data-init="storesInit" data-show="onStoresShow" data-stretch="true"
      data-model="storesListViewModel">
     <header data-role="header">
         <div data-role="navbar">
@@ -10,11 +10,13 @@
             </ul>
         </div>
     </header>
-    <div id="storesContent">
+    <div data-role="content" id="storesContent">
+        <div data-role="scroller">
+            <ul id="storeList" data-role="listview" data-style="inset" style="display:none"
+                data-template="tmplStoreListItem" data-bind="source: stores">
+            </ul>
+        </div>
         <div id="map"></div>
-        <ul id="storeList" data-role="listview" data-style="inset" style="display:none"
-            data-template="tmplStoreListItem" data-bind="source: stores">
-        </ul>
     </div>
     <span id="offline">Please reconnect to Internet.</span>
 </div>


### PR DESCRIPTION
The google map was not shown on iPhone device. Adding data-stretch="true"(http://docs.telerik.com/kendo-ui/api/javascript/mobile/ui/view#configuration-stretch) to fix this issue. Adding scroller to enable scroller for stores view after data-stretch="true".